### PR TITLE
@robertmkhall metadata data values are now first class 

### DIFF
--- a/lib/reporters/logs/json/console.ex
+++ b/lib/reporters/logs/json/console.ex
@@ -2,22 +2,38 @@ defmodule Extatic.Reporters.Logs.Json.Console do
   use GenEvent
 
   def init({__MODULE__, name}) do
-    {:ok, %{config: get_config(name)}}
+    {:ok, get_config(name)}
   end
 
-  def handle_event({level, _group_lead, {Logger, msg, ts, mdata}}, %{config: %{metadata: metadata, level: min_level}} = state) do
-    if is_nil(min_level) or Logger.compare_levels(level, min_level) != :lt do
-      event = %{
-        time: timestamp(ts),
-        level: level,
-        metadata: mdata |> Enum.into(metadata) |> Map.drop([:pid]),
-        message: msg |> to_string
-      } |> Poison.encode!
-
-      IO.puts(event)
+  def handle_event(data = {level, _grp_lead, {Logger, _msg, _ts, mdata}}, state = %{metadata: metadata, level: min_level}) do
+    if log_event?(level, min_level) do
+      data
+      |> format
+      |> merge_metadata(mdata, metadata)
+      |> Poison.encode!
+      |> IO.puts
     end
 
     {:ok, state}
+  end
+
+  defp merge_metadata(data, mdata, metadata) do
+    mdata
+    |> Enum.into(metadata)
+    |> Map.drop([:pid])
+    |> Map.merge(data)
+  end
+
+  defp format({level, _, {_, msg, ts, _}}) do
+    %{
+      time: timestamp(ts),
+      level: level,
+      message: msg |> to_string
+    }
+  end
+
+  def log_event?(level, min_level) do
+    is_nil(min_level) or Logger.compare_levels(level, min_level) != :lt
   end
 
   defp get_config(name) do


### PR DESCRIPTION
To ensure metdata values are picked up by services such as logstash, they are now moved out of a separate metadata map within the log map.

So...

```
{
  id: 3423432,
  metadata: {
    name: "application"
  }
}
```

becomes...

```
{
  id: 3423432,
  name: "application"
}
```
